### PR TITLE
Fix listing for `-l` case

### DIFF
--- a/jpsstat.sh
+++ b/jpsstat.sh
@@ -89,7 +89,7 @@ do
     do
         if [ $var = "-l" ]
         then
-            DATA=$(jps -l)
+            DATA=($(jps -l))
         fi
     done
 


### PR DESCRIPTION
Fix listing for `-l` case

Only the first java process was listed as `LINE` contains the whole content of `jps -l` for `-l` case, not just one line