### PR TITLE
skip empty java process name

### DIFF
--- a/jpsstat.sh
+++ b/jpsstat.sh
@@ -113,7 +113,7 @@ do
         TOKENS[1]=${TOKENS[1]##*[\\ /]}
 
         # skip the process if its Jps or Jstat itself 
-        if [ "${TOKENS[1]}" == "Jps" ] || [ "${TOKENS[1]}" == "sun.tools.jps.Jps" ] || [ "${TOKENS[1]}" == "Jstat" ] || [ "${TOKENS[1]}" == "sun.tools.jstat.Jstat" ]
+        if [ "${TOKENS[1]}" == "Jps" ] || [ "${TOKENS[1]}" == "sun.tools.jps.Jps" ] || [ "${TOKENS[1]}" == "Jstat" ] || [ "${TOKENS[1]}" == "sun.tools.jstat.Jstat" ] ||  [ -z "${TOKENS[1]}" ]
         then
             continue
         fi


### PR DESCRIPTION
when run jpstat.sh -1 on classic BIG-IP version 17.1.1 it gets output below with an empty java process name

14708 RestWorkerHost
19161 Main
14122       <====empty name here
18346 Bootstrap
13935 Jps

which result in printing error

./jpsstat.sh: line 145: printf: name>: invalid number26   26   26   26

1                      0    0    0    0   0

14122 <no                  0    26   26   26   26

fix it by ignoring empty process name